### PR TITLE
Introducing GOC main section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -49,3 +49,23 @@
 * [Committee funding](dao-committees/committee-funding.md)
 * [Coordinape](dao-committees/coordinape.md)
 * [FAQ](dao-committees/faq.md)
+
+## GOCs
+
+* GOC-0000 GOC Template
+* GOC-0001 Graph AdvocatesDAO Operating Code Structure
+* GOC-0002 DAO Membership
+* GOC-0003 DAO Committees
+* GOC-0004 Advocate Committee
+* GOC-0005 Grant Committee
+* GOC-0006 Ops Committee
+* GOC-0007 DAO Committee Approval Parameters
+* GOC-0008 DAO Funding
+* GOC-0009 DAO Budgeting
+* GOC-0010 Emergency Multisig
+* GOC-0011 Coordinape
+* GOC-0012 DAO Committee Compensation
+* GOC-0013 Graph Advocates Program Application
+* GOC-0014 Community Grant Application
+* GOC-0015 Twitter Management
+* GOC-0016 Email Management


### PR DESCRIPTION
GOC-0001 was approved and adopted by the DAO on May 4th, 2022 in DAOHaus. This new GOC main section aims to create a version controlled place for GOCs to be drafted and eventually be transparently published once individual GOCs are approved by the DAO. GOC-0002 through GOC-0016 have been added as placeholder pages. They are planned future GOCs that the DAO is looking to develop.